### PR TITLE
Enum reference list example to reference the correct gender enum

### DIFF
--- a/docs/back-end-basics/reference-lists.md
+++ b/docs/back-end-basics/reference-lists.md
@@ -29,8 +29,8 @@ For reference lists that are not expected to change **ever**, for example, 'Days
 public class Person
 {
    ...
-   [ReferenceList("MyModuleName", "Gender")]
-   public RefListDaysOfTheWeek Gender { get; set; } 
+   [ReferenceList("MyModule", "Gender")]
+   public RefListGender Gender { get; set; } 
    ...
 }
 ```


### PR DESCRIPTION
In Reference Lists -> Enum example the Person class is referencing a DaysOfTheWeek enum where the example should reference the Gender enum