### PR TITLE
'Shesha 3' references to just be 'Shesha'

### DIFF
--- a/docs/fundamentals/audit-logging.md
+++ b/docs/fundamentals/audit-logging.md
@@ -5,7 +5,7 @@ draft: true
 
 # Audit Logging
 
-Shesha 3 Entity History framework is based on Abp.EntityHistory <a href="https://aspnetboilerplate.com/Pages/Documents/Entity-History" target="_blank">https://aspnetboilerplate.com/Pages/Documents/Entity-History</a>
+Shesha Entity History framework is based on Abp.EntityHistory <a href="https://aspnetboilerplate.com/Pages/Documents/Entity-History" target="_blank">https://aspnetboilerplate.com/Pages/Documents/Entity-History</a>
 
 In addition, were added some Shesha specific features.
 

--- a/docs/manage-apps-and-users/audit-logging.md
+++ b/docs/manage-apps-and-users/audit-logging.md
@@ -1,6 +1,6 @@
 # Audit Logging
 
-Shesha 3 Entity History framework is based on Abp.EntityHistory (https://aspnetboilerplate.com/Pages/Documents/Entity-History)
+Shesha Entity History framework is based on Abp.EntityHistory (https://aspnetboilerplate.com/Pages/Documents/Entity-History)
 
 In addition, were added some Shesha specific features.
 


### PR DESCRIPTION
Some sections reference 'Shesha 3' this should just be 'Shesha'