### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/front-end-basics/configured-views/client-side-scripting/contexts/app-page-form-context.md
+++ b/docs/front-end-basics/configured-views/client-side-scripting/contexts/app-page-form-context.md
@@ -3,9 +3,9 @@ sidebar_position: 3
 ---
 # Application, page and form contexts
 
-Сontexts for storing temporary data for application, page and form.
+Contexts for storing temporary data for application, page and form.
 
-`appContext` - aplication level context. All data stored in this context is available on any page or form. It can be used to save any global application data, transfer data between pages, or store temporary data needed for the entire application.
+`appContext` - application level context. All data stored in this context is available on any page or form. It can be used to save any global application data, transfer data between pages, or store temporary data needed for the entire application.
 
 `pageContext` - page level context. All the data stored in this context is available inside the open page and the forms used on this page (Sub forms, Modal dialogs, Form cells, Data list items, etc.). It can be used to save any temporary data used on the page, transfer data between the forms used on the page. When closing/changing a page, all the page context data is cleared.
 
@@ -29,7 +29,7 @@ Please note that one `appContext` and one `pageContext` are always available for
 
 There is a Form with TextField and Text components.
 
-The TextField component binded to the `formContext` and `test` Property name.
+The TextField component bound to the `formContext` and `test` Property name.
 
 ![1742646916099](images/app-page-form-context/1742646916099.png)
 
@@ -43,6 +43,6 @@ So, the Text component shows values typed in the TextField component.
 
 Then this Form is used as a SubForm.
 
-Main fom contains TextField compenent (also binded to the `formContext` and `test` Property name) and two SubForm. So, it's mean that all TextField components are binded to the `formContext` and `test` Property name. But as can you see each TextField components binded to their own `formContext` and their values is not mixed
+Main form contains TextField component (also bound to the `formContext` and `test` Property name) and two SubForm. So, it means that all TextField components are bound to the `formContext` and `test` Property name. But as can you see each TextField component is bound to its own `formContext`, and their values are not mixed
 
 ![1742842987463](images/app-page-form-context/1742842987463.png)

--- a/docs/fundamentals/audit-logging.md
+++ b/docs/fundamentals/audit-logging.md
@@ -121,7 +121,7 @@ or
 
 # Audit trail of related or child entities
 
-By default the audit trail will only display changes to properties at the top level. It is however quite common to want to see changes occuring on child objects. Attributes that allow to include audit events of related or children entities to the Audit trail of entity
+By default the audit trail will only display changes to properties at the top level. It is however quite common to want to see changes occurring on child objects. Attributes that allow to include audit events of related or children entities to the Audit trail of entity
 
 ### Display events from related entity
 

--- a/docs/fundamentals/scheduled-jobs.md
+++ b/docs/fundamentals/scheduled-jobs.md
@@ -39,7 +39,7 @@ One of the most types of background jobs are those to send bulk notifications of
     description: "Sends reminders of appointments the day before the appointments.")]
 public class SendAppointmentReminderNotificationJob : ScheduledJobBase, ITransientDependency
 {
-    // Sql to retreive the list of valid Appointments scheduled for tomorrow for which a Reminder notification has not yet been sent according to the audit log in AbpTenantNotifications
+    // Sql to retrieve the list of valid Appointments scheduled for tomorrow for which a Reminder notification has not yet been sent according to the audit log in AbpTenantNotifications
     private const string SQL_SELECT_REMINDERS_TO_SEND = @"SELECT Id FROM Health_Appointments WHERE 
                                             IsDeleted = 0
                                         AND StatusLkp = 3 /*Booked*/

--- a/docs/fundamentals/user-registration.md
+++ b/docs/fundamentals/user-registration.md
@@ -62,7 +62,7 @@ The `UserEmailAsUsername` setting determines whether the system uses the user's 
 
 - Defines the URL to which the user will be redirected after successful registration. This ensures a seamless transition to the next step in the user journey.
 
-### Additional Registration Infomation
+### Additional Registration Information
 
 Defines a form for capturing extra details beyond basic user information. If enabled, the user must complete this form before completing the registration process.
 > _**NOTE**: If this option is selected then the registration process will be placed on draft until the form information has been completed and an additional endpoint (**`/api/services/app/UserManagement/CompleteRegistration`**) to finalize the registration has been actioned.

--- a/docs/fundamentals/validation.md
+++ b/docs/fundamentals/validation.md
@@ -37,7 +37,7 @@ With the exception of the last approach in the table above (which depends on the
 If the entity violates any validation rules, the Create(Post) or Update(Put) APIs will throw an `AbpValidationException` and return the appropriate validation information.
 
 ## Implementing Validations through FluentValidation
-In order for the implemented EntityValidator to trigger as mentioned in [https://docs.fluentvalidation.net/en/latest/](https://docs.fluentvalidation.net/en/latest/). Make sure to inlcude the `AbpFluentValidationModule` in the `WebCoreModule` class of the solution as a dependency.
+In order for the implemented EntityValidator to trigger as mentioned in [https://docs.fluentvalidation.net/en/latest/](https://docs.fluentvalidation.net/en/latest/). Make sure to include the `AbpFluentValidationModule` in the `WebCoreModule` class of the solution as a dependency.
 
 ##### Example
 ``` csharp


### PR DESCRIPTION
## Summary
- fix typographical errors in various docs

## Testing
- `npm test` *(fails: Missing script: "test")*